### PR TITLE
Travis: use cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ before_script:
 
 install: make install
 script: make test && make lint
+
+# @see https://github.com/nickstenning/travis-pip-cache/issues/1
+cache: pip


### PR DESCRIPTION
Inspired by https://github.com/nickstenning/travis-pip-cache/blob/master/.travis.yml

```
Collecting coverage==4.4.1 (from indexdigest==0.1.0)
 Using cached coverage-4.4.1-cp27-cp27mu-manylinux1_x86_64.whl
```