### PR TITLE
Introduce index_digest command line tool

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MESSAGES CONTROL]
-disable=too-few-public-methods
+disable=too-few-public-methods,fixme

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Analyses your database queries and schema and suggests indices improvements. You
 sudo apt-get install libmysqlclient-dev
 ```
 
+## An example
+
+```
+$ index_digest mysql://index_digest:qwerty@localhost/index_digest
+Found 2 issue(s) to report for "index_digest" database
+redundant_indices | 0004_id_foo: UNIQUE KEY idx (id, foo) index can be removed as redundant (covered by PRIMARY KEY (id, foo))
+redundant_indices | 0004_id_foo_bar: KEY idx_foo (foo) index can be removed as redundant (covered by KEY idx_foo_bar (foo, bar))
+```
+
 ## Read more
 
 * [High Performance MySQL, 3rd Edition by Vadim Tkachenko, Peter Zaitsev, Baron Schwartz](https://www.safaribooksonline.com/library/view/high-performance-mysql/9781449332471/ch05.html)

--- a/indexdigest/__init__.py
+++ b/indexdigest/__init__.py
@@ -1,0 +1,4 @@
+"""
+index_digest Python module
+"""
+VERSION = '0.1.0'

--- a/indexdigest/cli/__init__.py
+++ b/indexdigest/cli/__init__.py
@@ -1,0 +1,13 @@
+"""
+A module containing command-line tool
+"""
+import logging
+
+from os import getenv
+
+if getenv('DEBUG') == '1':
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s %(name)-35s %(levelname)-8s %(message)s',
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )

--- a/indexdigest/cli/script.py
+++ b/indexdigest/cli/script.py
@@ -17,6 +17,8 @@ Examples:
 
 Visit <https://github.com/macbre/index-digest>
 """
+from __future__ import print_function
+
 import logging
 from docopt import docopt
 

--- a/indexdigest/cli/script.py
+++ b/indexdigest/cli/script.py
@@ -1,0 +1,50 @@
+"""index_digest
+
+Analyses your database queries and schema and suggests indices improvements.
+
+Usage:
+  index_digest DSN
+  index_digest (-h | --help)
+  index_digest --version
+
+Options:
+  DSN               Data Source Name of database to check
+  -h --help         Show this screen.
+  --version         Show version.
+
+Examples:
+  index_digest mysql://index_digest:qwerty@localhost/index_digest
+
+Visit <https://github.com/macbre/index-digest>
+"""
+import logging
+from docopt import docopt
+
+import indexdigest
+from indexdigest.database import Database
+from indexdigest.linters import check_redundant_indices
+
+
+def main():
+    """ Main entry point for CLI"""
+    logger = logging.getLogger(__name__)
+
+    arguments = docopt(__doc__, version='index_digest {}'.format(indexdigest.VERSION))
+    logger.debug('Options: %s', arguments)
+
+    if 'DSN' not in arguments:
+        return
+
+    # connect to thhe database
+    database = Database.connect_dsn(arguments['DSN'])
+    logger.debug('Connected to MySQL server v%s', database.get_server_info())
+
+    # run all checks
+    reports = check_redundant_indices(database)
+
+    # emit results
+    print('Found {} issue(s) to report for "{}" database'.format(len(reports), database.db_name))
+
+    # TODO: implement formatters
+    for report in reports:
+        print('{} | {}'.format(report.linter_type, str(report)))

--- a/indexdigest/database.py
+++ b/indexdigest/database.py
@@ -32,6 +32,7 @@ class DatabaseBase(object):
         # lazy connect
         self._connection_params = dict(host=host, user=user, passwd=passwd, db=db)
         self._connection = None
+        self.db_name = db
 
     @classmethod
     def connect_dsn(cls, dsn):

--- a/indexdigest/database.py
+++ b/indexdigest/database.py
@@ -27,7 +27,8 @@ class DatabaseBase(object):
         :type passwd str
         :type db str
         """
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)
+        self.query_logger = logging.getLogger(__name__ + '.query')
 
         # lazy connect
         self._connection_params = dict(host=host, user=user, passwd=passwd, db=db)
@@ -64,7 +65,7 @@ class DatabaseBase(object):
         :type cursor_class MySQLdb.cursors.BaseCursor
         :rtype: MySQLdb.cursors.Cursor
         """
-        self.logger.info('Query: %s', sql)
+        self.query_logger.info('%s', sql)
 
         cursor = self.connection.cursor(cursorclass=cursor_class)
         cursor.execute(sql)

--- a/indexdigest/linters/__init__.py
+++ b/indexdigest/linters/__init__.py
@@ -1,24 +1,5 @@
 """
 Contains linters used to check the database for improvements.
 """
-
-
-class LinterEntry(object):
-    """
-    Wraps a single linter entry. Various formatters may display this data differently.
-    """
-    def __init__(self, linter_type, table_name, message, context=None):
-        """
-        :type linter_type str
-        :type table_name str
-        :type message str
-        :type context dict
-        """
-        self.linter_type = linter_type
-        self.table_name = table_name
-        self.message = message
-        self.context = context
-
-    def __str__(self):
-        return '{table_name}: {message}'.format(
-            table_name=self.table_name, message=self.message)
+# expose linters
+from .redundant_indices import check_redundant_indices

--- a/indexdigest/linters/redundant_indices.py
+++ b/indexdigest/linters/redundant_indices.py
@@ -1,7 +1,7 @@
 """
 This linter checks for redundant indices from a given set of them
 """
-from . import LinterEntry
+from indexdigest.utils import LinterEntry
 
 
 def get_redundant_indices(indices):

--- a/indexdigest/utils.py
+++ b/indexdigest/utils.py
@@ -1,5 +1,5 @@
 """
-This module contains utility functions
+This module contains utility functions and classes
 """
 try:
     from urlparse import urlparse  # Python2
@@ -27,3 +27,24 @@ def parse_dsn(dsn):
         'passwd': parsed.password,
         'db': str(parsed.path).lstrip('/')
     }
+
+
+class LinterEntry(object):
+    """
+    Wraps a single linter entry. Various formatters may display this data differently.
+    """
+    def __init__(self, linter_type, table_name, message, context=None):
+        """
+        :type linter_type str
+        :type table_name str
+        :type message str
+        :type context dict
+        """
+        self.linter_type = linter_type
+        self.table_name = table_name
+        self.message = message
+        self.context = context
+
+    def __str__(self):
+        return '{table_name}: {message}'.format(
+            table_name=self.table_name, message=self.message)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup, find_packages
 
+from indexdigest import VERSION
+
 # @see https://github.com/pypa/sampleproject/blob/master/setup.py
 setup(
     name='indexdigest',
-    version='0.1.0',
+    version=VERSION,
     author='Maciej Brencz',
     author_email='maciej.brencz@gmail.com',
     description='Analyses your database queries and schema and suggests indices improvements',
@@ -18,7 +20,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'index_digest=indexdigest.cli:main',
+            'index_digest=indexdigest.cli.script:main',
         ],
     }
 )


### PR DESCRIPTION
## An example

```
$ index_digest mysql://index_digest:qwerty@localhost/index_digest
Found 2 issue(s) to report for "index_digest" database
redundant_indices | 0004_id_foo: UNIQUE KEY idx (id, foo) index can be removed as redundant (covered by PRIMARY KEY (id, foo))
redundant_indices | 0004_id_foo_bar: KEY idx_foo (foo) index can be removed as redundant (covered by KEY idx_foo_bar (foo, bar))
```