### PR TITLE
queries_not_using_index: handle no matching row in const table

### DIFF
--- a/indexdigest/linters/__init__.py
+++ b/indexdigest/linters/__init__.py
@@ -2,9 +2,10 @@
 Contains linters used to check the database for improvements.
 """
 # expose linters
-from .linter_0002_not_used_indices import check_not_used_indices, check_queries_not_using_indices
-from .linter_0006_not_used_columns_and_tables import check_not_used_tables, check_not_used_columns
+from .linter_0002_not_used_indices import check_not_used_indices
 from .linter_0004_redundant_indices import check_redundant_indices
+from .linter_0006_not_used_columns_and_tables import check_not_used_tables, check_not_used_columns
+from .linter_0019_queries_not_using_indices import check_queries_not_using_indices
 from .linter_0020_filesort_temporary_table import \
     check_queries_using_filesort, check_queries_using_temporary
 from .linter_0026_full_table_scan import check_full_table_scan

--- a/indexdigest/linters/linter_0002_not_used_indices.py
+++ b/indexdigest/linters/linter_0002_not_used_indices.py
@@ -3,9 +3,9 @@ This linter checks for not used indices by going through SELECT queries
 """
 import logging
 
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
-from indexdigest.utils import LinterEntry, explain_queries, shorten_query
+from indexdigest.utils import LinterEntry, explain_queries
 
 
 def check_not_used_indices(database, queries):
@@ -34,28 +34,3 @@ def check_not_used_indices(database, queries):
                                   message='"{}" index was not used by provided queries'.
                                   format(index.name),
                                   context={"not_used_index": index})
-
-
-def check_queries_not_using_indices(database, queries):
-    """
-    :type database  indexdigest.database.Database
-    :type queries list[str]
-    :rtype: list[LinterEntry]
-    """
-    for (query, table_used, index_used, explain_row) in explain_queries(database, queries):
-        # print(query, explain_row)
-
-        if index_used is None:
-            context = OrderedDict()
-            context['query'] = query
-
-            # https://dev.mysql.com/doc/refman/5.7/en/explain-output.html#explain-extra-information
-            context['explain_extra'] = explain_row['Extra']
-            context['explain_rows'] = explain_row['rows']
-            context['explain_filtered'] = explain_row.get('filtered')  # can be not set
-            context['explain_possible_keys'] = explain_row['possible_keys']
-
-            yield LinterEntry(linter_type='queries_not_using_index', table_name=table_used,
-                              message='"{}" query did not make use of any index'.
-                              format(shorten_query(query)),
-                              context=context)

--- a/indexdigest/linters/linter_0019_queries_not_using_indices.py
+++ b/indexdigest/linters/linter_0019_queries_not_using_indices.py
@@ -1,0 +1,31 @@
+"""
+This linter checks SELECT queries that do not use indices
+"""
+from collections import OrderedDict
+
+from indexdigest.utils import LinterEntry, explain_queries, shorten_query
+
+
+def check_queries_not_using_indices(database, queries):
+    """
+    :type database  indexdigest.database.Database
+    :type queries list[str]
+    :rtype: list[LinterEntry]
+    """
+    for (query, table_used, index_used, explain_row) in explain_queries(database, queries):
+        # print(query, explain_row)
+
+        if index_used is None:
+            context = OrderedDict()
+            context['query'] = query
+
+            # https://dev.mysql.com/doc/refman/5.7/en/explain-output.html#explain-extra-information
+            context['explain_extra'] = explain_row['Extra']
+            context['explain_rows'] = explain_row['rows']
+            context['explain_filtered'] = explain_row.get('filtered')  # can be not set
+            context['explain_possible_keys'] = explain_row['possible_keys']
+
+            yield LinterEntry(linter_type='queries_not_using_index', table_name=table_used,
+                              message='"{}" query did not make use of any index'.
+                              format(shorten_query(query)),
+                              context=context)

--- a/indexdigest/linters/linter_0019_queries_not_using_indices.py
+++ b/indexdigest/linters/linter_0019_queries_not_using_indices.py
@@ -15,6 +15,14 @@ def check_queries_not_using_indices(database, queries):
     for (query, table_used, index_used, explain_row) in explain_queries(database, queries):
         # print(query, explain_row)
 
+        # EXPLAIN can return no matching row in const table in Extra column.
+        # Do not consider this query as not using an index. -- see #44
+        if explain_row['Extra'] in [
+                'Impossible WHERE noticed after reading const tables',
+                'no matching row in const table',
+        ]:
+            continue
+
         if index_used is None:
             context = OrderedDict()
             context['query'] = query

--- a/indexdigest/test/linters/test_0002_not_used_indices.py
+++ b/indexdigest/test/linters/test_0002_not_used_indices.py
@@ -2,8 +2,7 @@ from __future__ import print_function
 
 from unittest import TestCase
 
-from indexdigest.linters.linter_0002_not_used_indices import check_not_used_indices, \
-    check_queries_not_using_indices
+from indexdigest.linters.linter_0002_not_used_indices import check_not_used_indices
 from indexdigest.test import DatabaseTestMixin, read_queries_from_log
 
 
@@ -19,29 +18,5 @@ class TestNotUsedIndices(TestCase, DatabaseTestMixin):
         self.assertEqual(str(reports[0]), '0002_not_used_indices: "test_id_idx" index was not used by provided queries')
         self.assertEqual(reports[0].table_name, '0002_not_used_indices')
         self.assertEqual(str(reports[0].context['not_used_index']), 'KEY test_id_idx (test, id)')
-
-        # assert False
-
-
-class TestQueriesNotUsingIndices(TestCase, DatabaseTestMixin):
-
-    def test_queries(self):
-        reports = list(check_queries_not_using_indices(
-            database=self.connection, queries=read_queries_from_log('0019-queries-not-using-indices-log')))
-
-        # print(reports)
-
-        self.assertEqual(len(reports), 2)
-
-        self.assertEqual(str(reports[0]), '0019_queries_not_using_indices: "SELECT id FROM 0019_queries_not_using_indices WHER..." query did not make use of any index')
-        self.assertEqual(reports[0].table_name, '0019_queries_not_using_indices')
-        self.assertEqual(str(reports[0].context['query']), 'SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test" OR id > 1;')
-        self.assertEqual(str(reports[0].context['explain_extra']), 'Using where')
-        self.assertEqual(str(reports[0].context['explain_rows']), '3')
-
-        self.assertEqual(reports[1].table_name, '0019_queries_not_using_indices')
-        self.assertEqual(str(reports[1].context['query']), 'SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test"')
-        self.assertEqual(str(reports[1].context['explain_extra']), 'Using where')
-        self.assertEqual(str(reports[1].context['explain_rows']), '3')
 
         # assert False

--- a/indexdigest/test/linters/test_0019_queries_not_using_indices.py
+++ b/indexdigest/test/linters/test_0019_queries_not_using_indices.py
@@ -2,25 +2,8 @@ from __future__ import print_function
 
 from unittest import TestCase
 
-from indexdigest.linters.linter_0002_not_used_indices import check_not_used_indices, \
-    check_queries_not_using_indices
+from indexdigest.linters.linter_0019_queries_not_using_indices import check_queries_not_using_indices
 from indexdigest.test import DatabaseTestMixin, read_queries_from_log
-
-
-class TestNotUsedIndices(TestCase, DatabaseTestMixin):
-
-    def test_not_used_indices(self):
-        reports = list(check_not_used_indices(
-            database=self.connection, queries=read_queries_from_log('0002-not-used-indices-log')))
-
-        print(reports)
-
-        self.assertEqual(len(reports), 1)
-        self.assertEqual(str(reports[0]), '0002_not_used_indices: "test_id_idx" index was not used by provided queries')
-        self.assertEqual(reports[0].table_name, '0002_not_used_indices')
-        self.assertEqual(str(reports[0].context['not_used_index']), 'KEY test_id_idx (test, id)')
-
-        # assert False
 
 
 class TestQueriesNotUsingIndices(TestCase, DatabaseTestMixin):

--- a/indexdigest/test/linters/test_0019_queries_not_using_indices.py
+++ b/indexdigest/test/linters/test_0019_queries_not_using_indices.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+
+from unittest import TestCase
+
+from indexdigest.linters.linter_0002_not_used_indices import check_not_used_indices, \
+    check_queries_not_using_indices
+from indexdigest.test import DatabaseTestMixin, read_queries_from_log
+
+
+class TestNotUsedIndices(TestCase, DatabaseTestMixin):
+
+    def test_not_used_indices(self):
+        reports = list(check_not_used_indices(
+            database=self.connection, queries=read_queries_from_log('0002-not-used-indices-log')))
+
+        print(reports)
+
+        self.assertEqual(len(reports), 1)
+        self.assertEqual(str(reports[0]), '0002_not_used_indices: "test_id_idx" index was not used by provided queries')
+        self.assertEqual(reports[0].table_name, '0002_not_used_indices')
+        self.assertEqual(str(reports[0].context['not_used_index']), 'KEY test_id_idx (test, id)')
+
+        # assert False
+
+
+class TestQueriesNotUsingIndices(TestCase, DatabaseTestMixin):
+
+    def test_queries(self):
+        reports = list(check_queries_not_using_indices(
+            database=self.connection, queries=read_queries_from_log('0019-queries-not-using-indices-log')))
+
+        # print(reports)
+
+        self.assertEqual(len(reports), 2)
+
+        self.assertEqual(str(reports[0]), '0019_queries_not_using_indices: "SELECT id FROM 0019_queries_not_using_indices WHER..." query did not make use of any index')
+        self.assertEqual(reports[0].table_name, '0019_queries_not_using_indices')
+        self.assertEqual(str(reports[0].context['query']), 'SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test" OR id > 1;')
+        self.assertEqual(str(reports[0].context['explain_extra']), 'Using where')
+        self.assertEqual(str(reports[0].context['explain_rows']), '3')
+
+        self.assertEqual(reports[1].table_name, '0019_queries_not_using_indices')
+        self.assertEqual(str(reports[1].context['query']), 'SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test"')
+        self.assertEqual(str(reports[1].context['explain_extra']), 'Using where')
+        self.assertEqual(str(reports[1].context['explain_rows']), '3')
+
+        # assert False

--- a/sql/0019-queries-not-using-indices-log
+++ b/sql/0019-queries-not-using-indices-log
@@ -5,3 +5,5 @@ SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test" AND id = 1;
 -- these do not use index
 SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test" OR id > 1;
 SELECT id FROM 0019_queries_not_using_indices WHERE foo = "test"
+-- no matching row in const table (#44)
+SELECT foo FROM 0019_queries_not_using_indices WHERE id = 5;


### PR DESCRIPTION
Resolves #44