### PR TITLE
redundant_indices: avoid redundant indices being reported in a loop

### DIFF
--- a/indexdigest/linters/linter_0004_redundant_indices.py
+++ b/indexdigest/linters/linter_0004_redundant_indices.py
@@ -37,13 +37,22 @@ def check_redundant_indices(database):
         meta = database.get_table_metadata(table)
         schema = database.get_table_schema(table)
 
+        redundant_indices = set()
+
         for (redundant_index, suggested_index) in get_redundant_indices(indices):
+            # the index we're about to suggest was reported as redundant - #48
+            if suggested_index in redundant_indices:
+                continue
+
             context = OrderedDict()
             context['redundant'] = redundant_index
             context['covered_by'] = suggested_index
             context['schema'] = schema
             context['table_data_size_mb'] = 1. * meta['data_size'] / 1024 / 1024
             context['table_index_size_mb'] = 1. * meta['index_size'] / 1024 / 1024
+
+            # add to the list to avoid redundant indices being reported in a loop - #48
+            redundant_indices.add(redundant_index)
 
             yield LinterEntry(linter_type='redundant_indices', table_name=table,
                               message='"{}" index can be removed as redundant (covered by "{}")'.

--- a/indexdigest/test/linters/test_0004_redundant_indices.py
+++ b/indexdigest/test/linters/test_0004_redundant_indices.py
@@ -32,9 +32,10 @@ class TestRedundantIndices(TestCase, DatabaseTestMixin):
 
         print(reports)
 
-        self.assertEqual(len(reports), 2)
+        self.assertEqual(len(reports), 3)
         self.assertEqual(str(reports[0]), '0004_id_foo: "idx" index can be removed as redundant (covered by "PRIMARY")')
         self.assertEqual(str(reports[1]), '0004_id_foo_bar: "idx_foo" index can be removed as redundant (covered by "idx_foo_bar")')
+        self.assertEqual(str(reports[2]), '0004_indices_duplicating_each_other: "idx_foo" index can be removed as redundant (covered by "idx_foo_2")')
 
         report = reports[0]
 

--- a/sql/0004-redundant-indices.sql
+++ b/sql/0004-redundant-indices.sql
@@ -19,3 +19,13 @@ CREATE TABLE `0004_id_foo_bar` (
 	KEY `idx_foo_bar` (`foo`, `bar`),
 	KEY `idx_id_foo` (`id`, `foo`)
 );
+
+-- https://github.com/macbre/index-digest/issues/48
+DROP TABLE IF EXISTS `0004_indices_duplicating_each_other`;
+CREATE TABLE `0004_indices_duplicating_each_other` (
+	`id` int(9) NOT NULL AUTO_INCREMENT,
+	`foo` varbinary(16) NOT NULL DEFAULT '',
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `idx_foo` (`foo`),
+	UNIQUE KEY `idx_foo_2` (`foo`)
+);


### PR DESCRIPTION
Resolves #48
