### PR TITLE
Unique vs PK... Not necessarily redundant due to unique constraintprefer unique over non unique indices and primary keys over unique ones

### DIFF
--- a/indexdigest/schema.py
+++ b/indexdigest/schema.py
@@ -56,7 +56,11 @@ class Index(object):
         columns_cnt = len(self.columns)
 
         if self.columns == index.columns[:columns_cnt]:
-            return True
+            if self.is_unique and index.is_primary:
+                # the unique key adds a uniqueness bit to the primary key - #49
+                return False
+            else:
+                return True
 
         return False
 

--- a/indexdigest/schema.py
+++ b/indexdigest/schema.py
@@ -42,6 +42,16 @@ class Index(object):
         if self.is_primary or self == index:
             return False
 
+        # equal indices - prefer unique over non unique indices
+        # and primary keys over unique ones
+        # @see https://github.com/macbre/index-digest/issues/49
+        if self.columns == index.columns and self.is_unique:
+            # we're covered by the same unique key or a primary key
+            if index.is_unique or index.is_primary:
+                return True
+
+            return False
+
         # now take the subset of columns from the index we're comparing ourselves too
         columns_cnt = len(self.columns)
 

--- a/indexdigest/schema.py
+++ b/indexdigest/schema.py
@@ -59,8 +59,8 @@ class Index(object):
             if self.is_unique and index.is_primary:
                 # the unique key adds a uniqueness bit to the primary key - #49
                 return False
-            else:
-                return True
+
+            return True
 
         return False
 

--- a/indexdigest/test/core/test_indices.py
+++ b/indexdigest/test/core/test_indices.py
@@ -41,3 +41,34 @@ class TestIndex(TestCase):
 
         self.assertFalse(first.is_covered_by(second))
         self.assertFalse(second.is_covered_by(first))
+
+    def test_primary_and_unique_keys_coverage(self):
+        # @see https://github.com/macbre/index-digest/issues/49
+
+        # second key adds a uniqueness constraint, keep it
+        first = Index(name='base', columns=['id', 'bar', 'foo'], primary=True)
+        second = Index(name='base', columns=['bar', 'foo'], unique=True)
+
+        self.assertFalse(first.is_covered_by(second))
+        self.assertFalse(second.is_covered_by(first))
+
+        # these keys are the same (primary is unique)
+        first = Index(name='base', columns=['bar', 'foo'], primary=True)
+        second = Index(name='base', columns=['bar', 'foo'], unique=True)
+
+        self.assertFalse(first.is_covered_by(second))
+        self.assertTrue(second.is_covered_by(first))
+
+        # prefer unique over non-unique
+        first = Index(name='base', columns=['bar', 'foo'], unique=True)
+        second = Index(name='base', columns=['bar', 'foo'])
+
+        self.assertFalse(first.is_covered_by(second))
+        self.assertTrue(second.is_covered_by(first))
+
+        # identical unique indices
+        first = Index(name='base', columns=['bar', 'foo'], unique=True)
+        second = Index(name='base', columns=['bar', 'foo'], unique=True)
+
+        self.assertTrue(first.is_covered_by(second))
+        self.assertTrue(second.is_covered_by(first))

--- a/indexdigest/test/core/test_indices.py
+++ b/indexdigest/test/core/test_indices.py
@@ -46,8 +46,8 @@ class TestIndex(TestCase):
         # @see https://github.com/macbre/index-digest/issues/49
 
         # second key adds a uniqueness constraint, keep it
-        first = Index(name='base', columns=['id', 'bar', 'foo'], primary=True)
-        second = Index(name='base', columns=['bar', 'foo'], unique=True)
+        first = Index(name='base', columns=['bar', 'foo'], primary=True)
+        second = Index(name='base', columns=['bar'], unique=True)
 
         self.assertFalse(first.is_covered_by(second))
         self.assertFalse(second.is_covered_by(first))

--- a/indexdigest/test/linters/test_0004_redundant_indices.py
+++ b/indexdigest/test/linters/test_0004_redundant_indices.py
@@ -30,7 +30,7 @@ class TestRedundantIndices(TestCase, DatabaseTestMixin):
             reports
         ))
 
-        print(reports)
+        print(list(map(str,reports)))
 
         self.assertEqual(len(reports), 3)
         self.assertEqual(str(reports[0]), '0004_id_foo: "idx" index can be removed as redundant (covered by "PRIMARY")')

--- a/sql/0004-redundant-indices.sql
+++ b/sql/0004-redundant-indices.sql
@@ -29,3 +29,15 @@ CREATE TABLE `0004_indices_duplicating_each_other` (
 	UNIQUE KEY `idx_foo` (`foo`),
 	UNIQUE KEY `idx_foo_2` (`foo`)
 );
+
+-- https://github.com/macbre/index-digest/issues/49
+DROP TABLE IF EXISTS `0004_image_comment_temp`;
+CREATE TABLE /*_*/0004_image_comment_temp (
+  -- Key to img_name (ugh)
+  imgcomment_name varchar(255) binary NOT NULL,
+  -- Key to comment_id
+  imgcomment_description_id bigint unsigned NOT NULL,
+  PRIMARY KEY (imgcomment_name, imgcomment_description_id)
+) /*$wgDBTableOptions*/;
+-- Ensure uniqueness
+CREATE UNIQUE INDEX /*i*/imgcomment_name ON /*_*/0004_image_comment_temp (imgcomment_name);


### PR DESCRIPTION
Resolves #49 