### PR TITLE
tests: do not assume the version, silly me...

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Visit <https://github.com/macbre/index-digest>
 ```
 $ index_digest mysql://index_digest:qwerty@localhost/index_digest --sql-log sql/0002-not-used-indices-log 
 ------------------------------------------------------------
-Found 15 issue(s) to report for "index_digest" database
+Found 48 issue(s) to report for "index_digest" database
 ------------------------------------------------------------
-MySQL v5.5.58-0+deb8u1 at debian
-index-digest v0.1.0
+MySQL v5.7.20 at debian
+index-digest v0.2.0
 ------------------------------------------------------------
 redundant_indices → table affected: 0004_id_foo
 
@@ -219,6 +219,11 @@ selects_with_like → table affected: 0020_big_table
   - query: SELECT * FROM 0020_big_table WHERE text LIKE '%00'
   - explain_extra: Using where
   - explain_rows: 100623
+
+(...)
+
+------------------------------------------------------------
+Queries performed: 100
 ```
 
 ## SQL query log

--- a/indexdigest/test/formatters/test_plain.py
+++ b/indexdigest/test/formatters/test_plain.py
@@ -3,6 +3,7 @@ import re
 
 from unittest import TestCase
 
+from indexdigest import VERSION
 from indexdigest.formatters import format_plain as formatter
 from . import FormatterTestMixin
 
@@ -25,6 +26,7 @@ class TestFormatter(TestCase, FormatterTestMixin):
 
         assert 'Found 2 issue(s) to report for "test_database" database' in out
         assert 'MySQL v1.2.3-test at test.local' in out
+        assert 'index-digest v' + VERSION in out
 
         assert 'foo_linter → table affected: table_001' in out
         assert '✗ Something is fishy here' in out

--- a/indexdigest/test/formatters/test_syslog.py
+++ b/indexdigest/test/formatters/test_syslog.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from indexdigest import VERSION
 from indexdigest.formatters.syslog import format_report
 from . import FormatterTestMixin
 
@@ -12,7 +13,7 @@ class TestFormatter(TestCase, FormatterTestMixin):
         print(out, report)
 
         self.assertEquals(
-            '{"meta": {"version": "index-digest v0.1.0", "database_name": "test_database", '
+            '{"meta": {"version": "index-digest v' + VERSION + '", "database_name": "test_database", '
             '"database_host": "test.local", "database_version": "MySQL v1.2.3-test"}, '
             '"report": {"type": "foo_linter", "table": "table_001", "message": "Something is fishy here", '
             '"context": {"foo": 42, "test": "bar"}}}',

--- a/indexdigest/test/formatters/test_yaml.py
+++ b/indexdigest/test/formatters/test_yaml.py
@@ -2,6 +2,7 @@ import yaml
 
 from unittest import TestCase
 
+from indexdigest import VERSION
 from indexdigest.formatters import format_yaml as formatter
 from . import FormatterTestMixin
 
@@ -17,7 +18,7 @@ class TestFormatter(TestCase, FormatterTestMixin):
         assert 'meta' in res
         assert 'reports' in res
 
-        assert 'version: index-digest v0.1.0\n  database_name: test_database\n' \
+        assert 'version: index-digest v' + VERSION + '\n  database_name: test_database\n' \
             '  database_host: test.local\n  database_version: MySQL v1.2.3-test' in out
 
         assert 'message: Something is fishy here' in out


### PR DESCRIPTION
Avoid

```
E       AssertionError: '{"me[29 chars]t v0.1.0", "database_name": "test_database", "[200 chars]"}}}' != '{"me[29 chars]t v0.2.0", "database_name": "test_database", "[200 chars]"}}}'
E       Diff is 767 characters long. Set self.maxDiff to None to see it.
indexdigest/test/formatters/test_syslog.py:19: AssertionError
```