### PR TITLE
add_linter helper script

### DIFF
--- a/indexdigest/cli/add_linter.py
+++ b/indexdigest/cli/add_linter.py
@@ -28,11 +28,11 @@ def add_linter(linter_id, linter_name):
     sql_name = 'sql/{}-{}'.format(linter_id_fmt, linter_name.replace('_', '-'))
     logger.info("Add SQL schema and log files (%s) ...", sql_name)
 
-    with open(sql_name + '.sql', 'wt') as file:
+    with open(sql_name + '.sql', 'wt') as file_name:
         # 0002_not_used_indices
         table_name = '{}_{}'.format(linter_id_fmt, linter_name.replace('-', '_'))
 
-        file.writelines([
+        file_name.writelines([
             '-- Report ...\n',
             '--\n',
             '-- https://github.com/macbre/index-digest/issues/{}\n'.format(linter_id),
@@ -42,21 +42,21 @@ def add_linter(linter_id, linter_name):
             ');\n',
         ])
 
-        logger.info('... %s created', file.name)
+        logger.info('... %s created', file_name.name)
 
-    with open(sql_name + '-log', 'wt') as file:
-        file.writelines([
+    with open(sql_name + '-log', 'wt') as file_name:
+        file_name.writelines([
             '-- \n',
         ])
 
-        logger.info('... %s created', file.name)
+        logger.info('... %s created', file_name.name)
 
     # /indexdigest/linters directory
     logger.info("Add Python code ...")
 
     with open('indexdigest/linters/linter_{}_{}.py'.
-              format(linter_id_fmt, linter_name.replace('-', '_')), 'wt') as file:
-        file.writelines([
+              format(linter_id_fmt, linter_name.replace('-', '_')), 'wt') as file_name:
+        file_name.writelines([
             '"""\n',
             'This linter checks for ...\n',
             '"""\n',
@@ -78,15 +78,15 @@ def add_linter(linter_id, linter_name):
             '                      context={"foo": str("bar")})\n',
         ])
 
-        logger.info('... %s created', file.name)
+        logger.info('... %s created', file_name.name)
 
     logger.info("Add a test ...")
 
     with open('indexdigest/test/linters/test_{}_{}.py'.format(linter_id_fmt, linter_name), 'wt') \
-            as file:
+            as file_name:
         name = linter_name.replace('-', '_')
 
-        file.writelines([
+        file_name.writelines([
             'from __future__ import print_function\n',
             '\n',
             'from unittest import TestCase\n',
@@ -101,7 +101,7 @@ def add_linter(linter_id, linter_name):
             '        pass\n',
         ])
 
-        logger.info('... %s created', file.name)
+        logger.info('... %s created', file_name.name)
 
 
 def main():

--- a/indexdigest/cli/add_linter.py
+++ b/indexdigest/cli/add_linter.py
@@ -51,6 +51,35 @@ def add_linter(linter_id, linter_name):
 
         logger.info('... %s created', file.name)
 
+    # /indexdigest/linters directory
+    logger.info("Add Python code ...")
+
+    with open('indexdigest/linters/linter_{}_{}.py'.format(linter_id_fmt, linter_name), 'wt') \
+            as file:
+        file.writelines([
+            '"""\n',
+            'This linter checks for ...\n',
+            '"""\n',
+            'from collections import defaultdict\n',
+            '\n',
+            'from indexdigest.utils import LinterEntry, explain_queries\n',
+            '\n',
+            '\n',
+            'def check_not_used_indices(database, queries):\n',
+            '    """\n',
+            '    :type database  indexdigest.database.Database\n',
+            '    :type queries list[str]\n',
+            '    :rtype: list[LinterEntry]\n',
+            '    """\n',
+            '    yield LinterEntry(linter_type=\'{}\', table_name=table_name,\n'.
+            format(linter_name),
+            '                      message=\'"{}" ...\'.\n',
+            '                      format("foo"),\n',
+            '                      context={"foo": str("bar")})\n',
+        ])
+
+        logger.info('... %s created', file.name)
+
 
 def main():
     """

--- a/indexdigest/cli/add_linter.py
+++ b/indexdigest/cli/add_linter.py
@@ -54,8 +54,8 @@ def add_linter(linter_id, linter_name):
     # /indexdigest/linters directory
     logger.info("Add Python code ...")
 
-    with open('indexdigest/linters/linter_{}_{}.py'.format(linter_id_fmt, linter_name), 'wt') \
-            as file:
+    with open('indexdigest/linters/linter_{}_{}.py'.
+              format(linter_id_fmt, linter_name.replace('-', '_')), 'wt') as file:
         file.writelines([
             '"""\n',
             'This linter checks for ...\n',
@@ -76,6 +76,29 @@ def add_linter(linter_id, linter_name):
             '                      message=\'"{}" ...\'.\n',
             '                      format("foo"),\n',
             '                      context={"foo": str("bar")})\n',
+        ])
+
+        logger.info('... %s created', file.name)
+
+    logger.info("Add a test ...")
+
+    with open('indexdigest/test/linters/test_{}_{}.py'.format(linter_id_fmt, linter_name), 'wt') \
+            as file:
+        name = linter_name.replace('-', '_')
+
+        file.writelines([
+            'from __future__ import print_function\n',
+            '\n',
+            'from unittest import TestCase\n',
+            '\n',
+            'from indexdigest.linters.linter_{}_{} import check_foo\n'.format(linter_id_fmt, name),
+            'from indexdigest.test import DatabaseTestMixin, read_queries_from_log\n',
+            '\n',
+            '\n',
+            'class TestLinter(TestCase, DatabaseTestMixin):\n',
+            '\n',
+            '    def test_{}(self):\n'.format(name),
+            '        pass\n',
         ])
 
         logger.info('... %s created', file.name)

--- a/indexdigest/cli/add_linter.py
+++ b/indexdigest/cli/add_linter.py
@@ -1,0 +1,62 @@
+"""
+A helper script used to create files for new linter
+"""
+import logging
+import re
+import sys
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)-8s %(message)s',
+)
+
+
+def add_linter(linter_id, linter_name):
+    """
+    :type linter_id int
+    :type linter_name str
+    """
+    logger = logging.getLogger('add_linter')
+
+    # normalize values
+    linter_id_fmt = '{:04d}'.format(linter_id)
+    linter_name = re.sub(r'[^a-z]+', '-', linter_name.strip().lower())
+
+    logger.info("Creating a new linter: %s - %s ...", linter_id_fmt, linter_name)
+
+    # /sql directory
+    sql_name = 'sql/{}-{}'.format(linter_id_fmt, linter_name.replace('_', '-'))
+    logger.info("Add SQL schema and log files (%s) ...", sql_name)
+
+    with open(sql_name + '.sql', 'wt') as file:
+        # 0002_not_used_indices
+        table_name = '{}_{}'.format(linter_id_fmt, linter_name.replace('-', '_'))
+
+        file.writelines([
+            '-- Report ...\n',
+            '--\n',
+            '-- https://github.com/macbre/index-digest/issues/{}\n'.format(linter_id),
+            'DROP TABLE IF EXISTS `{}`;\n'.format(table_name),
+            'CREATE TABLE `{}` (\n'.format(table_name),
+            '-- \n',
+            ');\n',
+        ])
+
+        logger.info('... %s created', file.name)
+
+    with open(sql_name + '-log', 'wt') as file:
+        file.writelines([
+            '-- \n',
+        ])
+
+        logger.info('... %s created', file.name)
+
+
+def main():
+    """
+    usage: add_linter 89 empty_tables
+    """
+    linter_id = int(sys.argv[1])
+    linter_name = str(sys.argv[2])
+
+    add_linter(linter_id, linter_name)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'add_linter=indexdigest.cli.add_linter:main',  # creates a new linter from a template
             'index_digest=indexdigest.cli.script:main',
         ],
     }


### PR DESCRIPTION
```
$ add_linter 89 'empty_table'
INFO     Creating a new linter: 0089 - empty-table ...
INFO     Add SQL schema and log files (sql/0089-empty-table) ...
INFO     ... sql/0089-empty-table.sql created
INFO     ... sql/0089-empty-table-log created
INFO     Add Python code ...
INFO     ... indexdigest/linters/linter_0089_empty_table.py created
INFO     Add a test ...
INFO     ... indexdigest/test/linters/test_0089_empty-table.py created
```

> `id` is taken from GitHub issue - https://github.com/macbre/index-digest/issues/89

This creates the following files:

```
	indexdigest/linters/linter_0089_empty_table.py
	indexdigest/test/linters/test_0089_empty-table.py
	sql/0089-empty-table-log
	sql/0089-empty-table.sql
```
  