### PR TITLE
Improve get_used_tables_from_queries handling of table aliases

### DIFF
--- a/indexdigest/test/linters/test_0006_not_used_columns_and_tables.py
+++ b/indexdigest/test/linters/test_0006_not_used_columns_and_tables.py
@@ -40,12 +40,11 @@ class TestNotUsedTables(TestCase):
 
     def test_get_used_tables_from_queries(self):
         queries = [
-            'SELECT /* a comment */ foo FROM `0006_not_used_columns` WHERE id = 1;',
+            'SELECT /* a comment */ foo FROM `0006_not_used_columns` AS r WHERE id = 1;',  # table alias
             'SELECT 1 FROM `0006_not_used_tables` WHERE id = 3;',
         ]
 
-        tables = get_used_tables_from_queries(
-            database=self.connection, queries=queries)
+        tables = get_used_tables_from_queries(queries)
 
         print(tables)
 

--- a/indexdigest/test/test_0089_handle_sql_errors.py
+++ b/indexdigest/test/test_0089_handle_sql_errors.py
@@ -15,9 +15,7 @@ class ErrorsHandlingTest(TestCase, DatabaseTestMixin):
         return read_queries_from_log('0098-handle-sql-errors-log')
 
     def test_get_used_tables_from_queries(self):
-        tables = get_used_tables_from_queries(
-            database=self.connection,
-            queries=self.queries)
+        tables = get_used_tables_from_queries(self.queries)
 
         print(tables)
 

--- a/sql/0098-handle-sql-errors-log
+++ b/sql/0098-handle-sql-errors-log
@@ -1,9 +1,9 @@
 -- ERROR 1140 (42000): In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'index_digest.0020_big_table.val'; this is incompatible with sql_mode=only_full_group_by
-SELECT val, count(*) FROM 0020_big_table WHERE id BETWEEN 10 AND 20;
+SELECT val, count(*) FROM `0020_big_table` WHERE id BETWEEN 10 AND 20;
 
 -- query with aliases
-SELECT t.val as value, count(*) FROM 0020_big_table as t WHERE id BETWEEN 10 AND 20 GROUP BY val;
-SELECT val as value, count(*) FROM 0020_big_table WHERE id BETWEEN 10 AND 20 GROUP BY val;
+SELECT t.val as value, count(*) FROM `0020_big_table` as t WHERE id BETWEEN 10 AND 20 GROUP BY val;
+SELECT val as value, count(*) FROM `0020_big_table` WHERE id BETWEEN 10 AND 20 GROUP BY val;
 
 -- invalid syntax
 SELEKT foo FROM bar;


### PR DESCRIPTION
Use `sql_metadata.get_query_tables` instead of `EXPLAIN` query (that returns the table alias not its real name).

Example:

```sql
SELECT /* a comment */ foo FROM `0006_not_used_columns` AS r WHERE id = 1;
```