### PR TITLE
get_boundary_times: add @memoize

### DIFF
--- a/indexdigest/linters/linter_0028_data_too_old.py
+++ b/indexdigest/linters/linter_0028_data_too_old.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from datetime import datetime
 from time import time
 
-from indexdigest.utils import LinterEntry
+from indexdigest.utils import LinterEntry, memoize
 
 
 def get_time_columns(database):
@@ -28,6 +28,7 @@ def get_time_columns(database):
         yield (table_name, time_columns[0])
 
 
+@memoize
 def get_boundary_times(database, table_name, column):
     """
     :type database  indexdigest.database.Database


### PR DESCRIPTION
Otherwise `check_data_not_updated_recently` and `check_data_too_old` will run these (possibly heavy) queries twice:

```sql
2018-02-02 12:39:24 indexdigest.database.query          INFO     SELECT /* index-digest */ UNIX_TIMESTAMP(MIN(`msg_date`)) as `min`, UNIX_TIMESTAMP(MAX(`msg_date`)) as `max` FROM messages_status
```