### PR TITLE
get_boundary_times | handle tables with dashes

### DIFF
--- a/indexdigest/linters/linter_0028_data_too_old.py
+++ b/indexdigest/linters/linter_0028_data_too_old.py
@@ -38,7 +38,7 @@ def get_boundary_times(database, table_name, column):
     """
     # this may take a while when {column} is not indexed!
     query = 'SELECT /* index-digest */ UNIX_TIMESTAMP(MIN(`{column}`)) as `min`, ' \
-            'UNIX_TIMESTAMP(MAX(`{column}`)) as `max` FROM {table}'.\
+            'UNIX_TIMESTAMP(MAX(`{column}`)) as `max` FROM `{table}`'.\
         format(
             column=column.name,
             table=table_name


### PR DESCRIPTION
```sql
2018-03-13 08:34:04 indexdigest.database.query          INFO     SELECT /* index-digest */ UNIX_TIMESTAMP(MIN(`created`)) as `min`, UNIX_TIMESTAMP(MAX(`created`)) as `max` FROM foo_bar-metadata
2018-03-13 08:34:04 indexdigest.database.query          ERROR    Database error #1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to 
```