### PR TITLE
Dockerize index-digest and push it to Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# hidden files and directories
+.*/*
+
+# shell scripts and Makefile
+*.sh
+Makefile
+
+# virtual environments
+env*
+
+# Python-specific stuff
+*.egg-info/
+dist/
+htmlcov/
+coverage.xml
+
+# SQL fixtures and tests
+setup.sql
+sql/
+
+# READMEs
+*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # hidden files and directories
-.*/*
+.*
 
 # shell scripts and Makefile
 *.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# https://hub.docker.com/_/python/
+FROM python:3.6-slim
+
+WORKDIR /opt/macbre/index-digest
+
+# install dependencies
+ADD setup.py ./
+ADD indexdigest/__init__.py ./indexdigest/__init__.py
+
+# installs mysql_config and pip dependencies
+# https://github.com/gliderlabs/docker-alpine/issues/181
+RUN apt-get update && apt-get install -y libmariadbclient-dev gcc \
+    && pip install . \
+    && rm -rf .cache/pip \
+    && apt-get remove -y gcc && apt-get autoremove -y
+
+# install the remaining files
+ADD . .
+
+USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ADD indexdigest/__init__.py ./indexdigest/__init__.py
 # installs mysql_config and pip dependencies
 # https://github.com/gliderlabs/docker-alpine/issues/181
 RUN apt-get update && apt-get install -y libmariadbclient-dev gcc \
-    && pip install . \
-    && rm -rf .cache/pip \
+    && pip install indexdigest \
+    && rm -rf ~/.cache/pip \
     && apt-get remove -y gcc && apt-get autoremove -y
 
 # install the remaining files

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,6 @@ RUN apt-get update && apt-get install -y libmariadbclient-dev gcc \
 ADD . .
 
 USER nobody
+
+# docker run -t macbre/index-digest
+ENTRYPOINT ["index_digest"]

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 	pylint $(project_name)/ --ignore=test
 
 demo:
-	index_digest mysql://index_digest:qwerty@127.0.0.1/index_digest --sql-log sql/0002-not-used-indices-log --analyze-data --check-empty-databases --skip-checks=non_utf_columns --skip-tables=0028_no_time
+	docker run --network=host -t macbre/index-digest:latest mysql://index_digest:qwerty@127.0.0.1/index_digest --analyze-data --skip-checks=non_utf_columns --skip-tables=0028_no_time
 
 sql-console:
 	mysql --prompt='mysql@\h[\d]>' --protocol=tcp -uindex_digest -pqwerty index_digest

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,16 @@ sql-console:
 publish:
 	# run git tag -a v0.0.0 before running make publish
 	python setup.py sdist upload -r pypi
+
+# docker
+VERSION = "1.2.0"
+
+build:
+	@docker build -t macbre/index-digest:$(VERSION) . \
+	&& docker tag macbre/index-digest:$(VERSION) macbre/index-digest:latest
+
+push: build
+	@docker push macbre/index-digest:$(VERSION) \
+	&& docker push macbre/index-digest:latest
+
+.PHONY: build

--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ source env/bin/activate
 make install
 ```
 
+### Using Docker
+
+> See https://hub.docker.com/r/macbre/index-digest/
+
+```
+$ docker run --network=host -t macbre/index-digest:latest mysql://index_digest:qwerty@debian/index_digest  | head -n 20
+------------------------------------------------------------
+Found 61 issue(s) to report for "index_digest" database
+------------------------------------------------------------
+MySQL v5.7.22 at debian
+index-digest v1.2.0
+------------------------------------------------------------
+redundant_indices → table affected: 0004_id_foo
+
+✗ "idx" index can be removed as redundant (covered by "PRIMARY")
+
+  - redundant: UNIQUE KEY idx (item_id, foo)
+  - covered_by: PRIMARY KEY (item_id, foo)
+  - schema: CREATE TABLE `0004_id_foo` (
+      `item_id` int(9) NOT NULL AUTO_INCREMENT,
+      `foo` varbinary(16) NOT NULL DEFAULT '',
+      PRIMARY KEY (`item_id`,`foo`),
+      UNIQUE KEY `idx` (`item_id`,`foo`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=latin1
+  - table_data_size_mb: 0.015625
+  - table_index_size_mb: 0.015625
+...
+```
+
 ## How to run it?
 
 ```


### PR DESCRIPTION
Resolves #150

Example:

```
docker run --network=host -t macbre/index-digest:latest mysql://index_digest:qwerty@127.0.0.1/index_digest --analyze-data --skip-checks=non_utf_columns --skip-tables=0028_no_time
```