### PR TITLE
Update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ project_name = indexdigest
 coverage_options = --include='$(project_name)/*' --omit='$(project_name)/test/*'
 
 install:
-	pip install -U -e .
+	pip install -U -e .[dev]
 
 test:
-	py.test -x $(project_name)
+	pytest -x $(project_name)
 
 coverage:
 	rm -f .coverage*
 	rm -rf htmlcov/*
-	coverage run -p -m py.test -x $(project_name)
+	coverage run -p -m pytest -x $(project_name)
 	coverage combine
 	coverage html -d htmlcov $(coverage_options)
 	coverage xml -i
@@ -27,7 +27,8 @@ sql-console:
 
 publish:
 	# run git tag -a v0.0.0 before running make publish
-	python setup.py sdist upload -r pypi
+	python setup.py sdist
+	twine upload --skip-existing dist/*
 
 # docker (tag with commit ID)
 VERSION = "1.2.0-"$(shell git rev-parse --short HEAD)

--- a/indexdigest/test/linters/test_0093_having_clause.py
+++ b/indexdigest/test/linters/test_0093_having_clause.py
@@ -34,9 +34,9 @@ class TestLinter(TestCase, DatabaseTestMixin):
         assert reports[0].table_name == 'foo'
         assert reports[0].context['query'] == 'SELECT * FROM foo HAVING bar = 2;'
 
-        assert str(reports[1]) == 'sales: "SELECT s.cust_id,count(s.cust_id) ' \
+        assert str(reports[1]) == 'SH.sales: "SELECT s.cust_id,count(s.cust_id) ' \
                                   'FROM SH.sales s ..." query uses HAVING clause'
-        assert reports[1].table_name == 'sales'
+        assert reports[1].table_name == 'SH.sales'
 
         assert str(reports[2]) == '0019_queries_not_using_indices: "SELECT * FROM ' \
                                   '`0019_queries_not_using_indices` WHE..." query uses HAVING clause'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from setuptools import setup, find_packages
 
 from indexdigest import VERSION
 
+# @see https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 # @see https://github.com/pypa/sampleproject/blob/master/setup.py
 setup(
     name='indexdigest',
@@ -10,6 +14,8 @@ setup(
     author_email='maciej.brencz@gmail.com',
     license='MIT',
     description='Analyses your database queries and schema and suggests indices and schema improvements',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/macbre/index-digest',
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -37,11 +43,16 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     packages=find_packages(),
+    extras_require={
+        'dev': [
+            'coverage==4.5.2',
+            'pylint>=1.9.2, <=2.1.1',  # 2.x branch is for Python 3
+            'pytest==4.0.0',
+            'twine==1.12.1',
+        ]
+    },
     install_requires=[
         'docopt==0.6.2',
-        'coverage==4.5.1',
-        'pylint==1.9.3',
-        'pytest==3.8.0',
         'PyYAML==3.13',
         'mysqlclient==1.3.13',
         'sql_metadata==1.1.2',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'docopt==0.6.2',
         'PyYAML==3.13',
         'mysqlclient==1.3.13',
-        'sql_metadata==1.1.2',
+        'sql_metadata==1.3',
         'termcolor==1.1.0',
         'yamlordereddictloader==0.4.0'
     ],


### PR DESCRIPTION
New version of `sql_metadata` will report full table names including database name if they're provided in a form of `db.table_name` in SQL queries.