### PR TITLE
Allow port to be specified in DSN

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,4 @@
 [MESSAGES CONTROL]
 disable=too-few-public-methods,fixme,no-member,duplicate-code,useless-object-inheritance
+[DESIGN]
+max-args=7

--- a/indexdigest/database.py
+++ b/indexdigest/database.py
@@ -27,7 +27,7 @@ class DatabaseBase(object):
     Sub-class this to mock database connection
     """
 
-    def __init__(self, host, user, passwd, db):
+    def __init__(self, host, user, passwd, db, port=3306):
         """
         Connects to a given database
 
@@ -40,7 +40,7 @@ class DatabaseBase(object):
         self.query_logger = logging.getLogger(__name__ + '.query')
 
         # lazy connect
-        self._connection_params = dict(host=host, user=user, passwd=passwd, db=db)
+        self._connection_params = dict(host=host, port=port, user=user, passwd=passwd, db=db)
         self._connection = None
         self.db_name = db
 
@@ -67,8 +67,9 @@ class DatabaseBase(object):
         :rtype: Connection
         """
         if self._connection is None:
-            self.logger.info('Lazy connecting to %s and using %s database',
-                             self._connection_params['host'], self._connection_params['db'])
+            self.logger.info('Lazy connecting to %s:%i and using %s database',
+                             self._connection_params['host'], self._connection_params['port'],
+                             self._connection_params['db'])
 
             self._connection = MySQLdb.connect(**self._connection_params)
 

--- a/indexdigest/test/core/test_utils.py
+++ b/indexdigest/test/core/test_utils.py
@@ -9,6 +9,16 @@ class TestUtils(TestCase):
         parsed = parse_dsn('mysql://alex:pwd@localhost/test')
 
         self.assertEqual('localhost', parsed['host'])
+        self.assertEqual(3306, parsed['port'])
+        self.assertEqual('alex', parsed['user'])
+        self.assertEqual('pwd', parsed['passwd'])
+        self.assertEqual('test', parsed['db'])
+
+    def test_parse_dsn_with_port(self):
+        parsed = parse_dsn('mysql://alex:pwd@localhost:5000/test')
+
+        self.assertEqual('localhost', parsed['host'])
+        self.assertEqual(5000, parsed['port'])
         self.assertEqual('alex', parsed['user'])
         self.assertEqual('pwd', parsed['passwd'])
         self.assertEqual('test', parsed['db'])

--- a/indexdigest/utils.py
+++ b/indexdigest/utils.py
@@ -27,6 +27,7 @@ def parse_dsn(dsn):
 
     return {
         'host': parsed.hostname,
+        'port': int(parsed.port) if parsed.port else 3306,
         'user': parsed.username,
         'passwd': parsed.password,
         'db': str(parsed.path).lstrip('/')


### PR DESCRIPTION
A small change that allows a non-default port to be specified in the DSN. If it's left out, it will default to 3306.