### PR TITLE
Improve low cardinality indices detection

### DIFF
--- a/indexdigest/database.py
+++ b/indexdigest/database.py
@@ -266,11 +266,13 @@ class Database(DatabaseBase):
         :type table_name str
         :rtype: dict
         """
-        # @see https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
+        # https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
+        # https://mariadb.com/kb/en/information-schema-tables-table/
         stats = self.query_dict_row(
             "SELECT ENGINE, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH "
             "FROM information_schema.TABLES " + self._get_information_schema_where(table_name))
 
+        # TODO: introduce dataclass
         return {
             'engine': stats['ENGINE'],
             'rows': stats['TABLE_ROWS'],  # For InnoDB the row count is only a rough estimate

--- a/indexdigest/linters/linter_0031_low_cardinality_index.py
+++ b/indexdigest/linters/linter_0031_low_cardinality_index.py
@@ -35,14 +35,14 @@ def get_low_cardinality_indices(database):
                 table_name=table_name, database_name=database.db_name)
         )
 
-        print('get_low_cardinality_indices', list(indices))
-
         for index in indices:
+            print('idx', table_name, rows_count, index)
+
             # the cardinality is too high
             if index['CARDINALITY'] > INDEX_CARDINALITY_THRESHOLD:
                 continue
 
-            yield (table_name, rows_count, index)
+            yield table_name, rows_count, index
 
 
 def check_low_cardinality_index(database):

--- a/indexdigest/linters/linter_0031_low_cardinality_index.py
+++ b/indexdigest/linters/linter_0031_low_cardinality_index.py
@@ -36,8 +36,6 @@ def get_low_cardinality_indices(database):
         )
 
         for index in indices:
-            print('idx', table_name, rows_count, index)
-
             # the cardinality is too high
             if index['CARDINALITY'] > INDEX_CARDINALITY_THRESHOLD:
                 continue

--- a/indexdigest/linters/linter_0031_low_cardinality_index.py
+++ b/indexdigest/linters/linter_0031_low_cardinality_index.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 from indexdigest.utils import LinterEntry
 
 # skip small tables
-ROWS_COUNT_THRESHOLD = 1000
+ROWS_COUNT_THRESHOLD = 100000
 
 # cardinality threshold
-INDEX_CARDINALITY_THRESHOLD = 5
+INDEX_CARDINALITY_THRESHOLD = 6
 
 # the least frequent value should be used at most by x% rows
 INDEX_VALUE_PERCENTAGE_THRESHOLD = 20

--- a/indexdigest/linters/linter_0031_low_cardinality_index.py
+++ b/indexdigest/linters/linter_0031_low_cardinality_index.py
@@ -35,6 +35,8 @@ def get_low_cardinality_indices(database):
                 table_name=table_name, database_name=database.db_name)
         )
 
+        print('get_low_cardinality_indices', list(indices))
+
         for index in indices:
             # the cardinality is too high
             if index['CARDINALITY'] > INDEX_CARDINALITY_THRESHOLD:

--- a/indexdigest/test/core/test_database.py
+++ b/indexdigest/test/core/test_database.py
@@ -150,7 +150,7 @@ class TestDatabase(TestCase, DatabaseTestMixin):
 
         # stats
         self.assertEqual(meta['engine'], 'InnoDB')
-        self.assertEqual(meta['rows'], 3)
+        self.assertAlmostEqual(meta['rows'], 3, delta=1)
         self.assertTrue(meta['index_size'] > 0)
         self.assertTrue(meta['data_size'] > 0)
 
@@ -180,7 +180,7 @@ class TestDatabase(TestCase, DatabaseTestMixin):
         # assert False
 
     def test_get_table_rows_estimate(self):
-        self.assertEqual(self.connection.get_table_rows_estimate(self.TABLE_NAME), 3)
+        self.assertAlmostEqual(self.connection.get_table_rows_estimate(self.TABLE_NAME), 3, delta=1)
 
 
 class TestsWithDatabaseMocked(TestCase):

--- a/indexdigest/test/linters/test_0031_low_cardinality_index.py
+++ b/indexdigest/test/linters/test_0031_low_cardinality_index.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from unittest import TestCase
 
 from indexdigest.linters.linter_0031_low_cardinality_index import \
-    check_low_cardinality_index, get_low_cardinality_indices
+    check_low_cardinality_index, get_low_cardinality_indices, INDEX_CARDINALITY_THRESHOLD
 from indexdigest.test import DatabaseTestMixin
 
 
@@ -15,11 +15,13 @@ class TestLinter(TestCase, DatabaseTestMixin):
         print(indices)
 
         assert len(indices) == 1
-        assert indices[0][0] == '0020_big_table'
-        assert indices[0][2]['INDEX_NAME'] == 'num_idx'
-        assert indices[0][2]['COLUMN_NAME'] == 'num'
-        assert indices[0][2]['CARDINALITY'] > 1
-        assert indices[0][2]['CARDINALITY'] < 5
+
+        index = indices[0]
+        assert index[0] == '0020_big_table'
+        assert index[2]['INDEX_NAME'] == 'num_idx'
+        assert index[2]['COLUMN_NAME'] == 'num'
+        assert index[2]['CARDINALITY'] > 1
+        assert index[2]['CARDINALITY'] <= INDEX_CARDINALITY_THRESHOLD
 
     def test_low_cardinality_index(self):
         reports = list(check_low_cardinality_index(self.connection))


### PR DESCRIPTION
And fix integration tests

### Examples

```sql
-- Server version:		8.0.20 MySQL Community Server - GPL

mysql> select TABLE_NAME, INDEX_NAME, COLUMN_NAME, CARDINALITY from INFORMATION_SCHEMA.STATISTICS where table_name = '0020_big_table';
+----------------+------------+-------------+-------------+
| TABLE_NAME     | INDEX_NAME | COLUMN_NAME | CARDINALITY |
+----------------+------------+-------------+-------------+
| 0020_big_table | num_idx    | num         |           2 |
| 0020_big_table | PRIMARY    | item_id     |      100256 |
| 0020_big_table | text_idx   | text        |      100256 |
+----------------+------------+-------------+-------------+
3 rows in set (0.00 sec)
```

vs

```sql
-- Server version:		5.5.5-10.5.4-MariaDB-1:10.5.4+maria~focal mariadb.org binary distribution

mysql> select TABLE_NAME, INDEX_NAME, COLUMN_NAME, CARDINALITY from INFORMATION_SCHEMA.STATISTICS where table_name = '0020_big_table';
+----------------+------------+-------------+-------------+
| TABLE_NAME     | INDEX_NAME | COLUMN_NAME | CARDINALITY |
+----------------+------------+-------------+-------------+
| 0020_big_table | PRIMARY    | item_id     |      100256 |
| 0020_big_table | text_idx   | text        |      100256 |
| 0020_big_table | num_idx    | num         |           4 |
+----------------+------------+-------------+-------------+
3 rows in set (0.00 sec)
```

```python
indexdigest/test/linters/test_0031_low_cardinality_index.py:17: AssertionError
----------------------------- Captured stdout call -----------------------------
get_low_cardinality_indices [{'TABLE_NAME': '0020_big_table', 'INDEX_NAME': 'PRIMARY', 'COLUMN_NAME': 'item_id', 'CARDINALITY': 100000}, {'TABLE_NAME': '0020_big_table', 'INDEX_NAME': 'text_idx', 'COLUMN_NAME': 'text', 'CARDINALITY': 100000}, {'TABLE_NAME': '0020_big_table', 'INDEX_NAME': 'num_idx', 'COLUMN_NAME': 'num', 'CARDINALITY': 6}]
```