### PR TITLE
CI | run database on a custom port

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -70,7 +70,7 @@ jobs:
         mysql --protocol=tcp --port=53306 -u root --password="" -v < setup.sql
         # import the test schema files
         "./sql/populate.sh"
-        mysql --protocol=tcp -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
+        mysql --protocol=tcp --port=53306 -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
 
     - name: Tests
       run: make test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
                 MYSQL_ALLOW_EMPTY_PASSWORD: yes
                 MYSQL_DATABASE: index_digest
             ports:
-                - "3306:3306"
+              - "53306:3306"
             options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
@@ -57,7 +57,9 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
-      run: make install
+      run: |
+        pip install wheel
+        make install
 
     - name: Linter
       run: make lint
@@ -65,7 +67,7 @@ jobs:
     - name: Set up the database
       run: |
         docker ps
-        mysql --protocol=tcp -u root -v < setup.sql
+        mysql --protocol=tcp --port=53306 -u root --password="" -v < setup.sql
         # import the test schema files
         "./sql/populate.sh"
         mysql --protocol=tcp -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         mysql --protocol=tcp --port=53306 -u root --password="" -v < setup.sql
         # import the test schema files
         "./sql/populate.sh"
-        mysql --protocol=tcp -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
+        mysql --protocol=tcp --port=53306 -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
 
     - name: Tests
       run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Set up the database
       run: |
         docker ps
-        mysql --protocol=tcp -u root -v < setup.sql
+        mysql --protocol=tcp --port=53306 -u root --password="" -v < setup.sql
         # import the test schema files
         "./sql/populate.sh"
         mysql --protocol=tcp -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
                 MYSQL_ALLOW_EMPTY_PASSWORD: yes
                 MYSQL_DATABASE: index_digest
             ports:
-                - "3306:3306"
+                - "53306:3306"
             options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,9 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
-      run: make install
+      run: |
+        pip install wheel
+        make install
 
     - name: Linter
       run: make lint

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ make install
 We assume database is running locally on port 3306. You can use the following to test your changes locally before pushing them (this one uses MySQL 8.0.20):
 
 ```
-docker run -p 53306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=index_digest" --name=index_digest_mysql mysql:8.0.20
+docker run --rm -p 53306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=index_digest" --name=index_digest_mysql mysql:8.0.22 "--default-authentication-plugin=mysql_native_password"
 ```
 
 Wait until the server is up and running.
 
 ```
-mysql --protocol=tcp --port=53306 -u root -v < setup.sql
+mysql --protocol=tcp --port=53306 -u root --password="" -v < setup.sql
 ./sql/populate.sh
 mysql --protocol=tcp --port=53306 -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ make install
 We assume database is running locally on port 3306. You can use the following to test your changes locally before pushing them (this one uses MySQL 8.0.20):
 
 ```
-docker run -p 3306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=index_digest" mysql:8.0.20
+docker run -p 53306:3306 --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=index_digest" --name=index_digest_mysql mysql:8.0.20
 ```
 
 Wait until the server is up and running.
 
 ```
-mysql --protocol=tcp -u root -v < setup.sql
+mysql --protocol=tcp --port=53306 -u root -v < setup.sql
 ./sql/populate.sh
-mysql --protocol=tcp -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
+mysql --protocol=tcp --port=53306 -uindex_digest -pqwerty index_digest -v -e '\s; SHOW TABLES; SHOW DATABASES;'
 
 make test
 ```

--- a/indexdigest/test/__init__.py
+++ b/indexdigest/test/__init__.py
@@ -16,7 +16,7 @@ def read_queries_from_log(log_file):
 
 
 class DatabaseTestMixin(object):
-    DSN = 'mysql://index_digest:qwerty@127.0.0.1/index_digest'
+    DSN = 'mysql://index_digest:qwerty@127.0.0.1:53306/index_digest'
 
     @property
     def connection(self):

--- a/sql/populate.sh
+++ b/sql/populate.sh
@@ -5,6 +5,6 @@ FILES=`ls sql/*.sql`
 for FILE in $FILES
 do
 	echo -n "* Importing ${FILE} ... "
-	cat $FILE | mysql --protocol=tcp -uindex_digest -pqwerty index_digest 2>&1 | grep -v "Using a password"
+	cat $FILE | mysql --protocol=tcp --port=53306 -uindex_digest -pqwerty index_digest 2>&1 | grep -v "Using a password"
 	echo "done"
 done


### PR DESCRIPTION
This will ease a local development in case a local MySQL instance is running on a default port (3306).