### PR TITLE
Improve queries_not_using_index linter

### DIFF
--- a/indexdigest/linters/linter_0019_queries_not_using_indices.py
+++ b/indexdigest/linters/linter_0019_queries_not_using_indices.py
@@ -16,7 +16,7 @@ def check_queries_not_using_indices(database, queries):
         # print(query, explain_row)
 
         # EXPLAIN can return no matching row in const table in Extra column.
-        # Do not consider this query as not using an index. -- see #44 and 210
+        # Do not consider this query as not using an index. -- see #44 and #210
         if explain_row['Extra'] in [
                 'Impossible WHERE noticed after reading const tables',
                 'no matching row in const table',

--- a/indexdigest/linters/linter_0019_queries_not_using_indices.py
+++ b/indexdigest/linters/linter_0019_queries_not_using_indices.py
@@ -22,6 +22,7 @@ def check_queries_not_using_indices(database, queries):
                 'no matching row in const table',
                 'No tables used',
                 'Select tables optimized away',
+                'No matching min/max row',
         ]:
             continue
 

--- a/indexdigest/linters/linter_0019_queries_not_using_indices.py
+++ b/indexdigest/linters/linter_0019_queries_not_using_indices.py
@@ -16,11 +16,12 @@ def check_queries_not_using_indices(database, queries):
         # print(query, explain_row)
 
         # EXPLAIN can return no matching row in const table in Extra column.
-        # Do not consider this query as not using an index. -- see #44
+        # Do not consider this query as not using an index. -- see #44 and 210
         if explain_row['Extra'] in [
                 'Impossible WHERE noticed after reading const tables',
                 'no matching row in const table',
-                'No tables used'
+                'No tables used',
+                'Select tables optimized away',
         ]:
             continue
 

--- a/indexdigest/test/linters/test_0019_queries_not_using_indices.py
+++ b/indexdigest/test/linters/test_0019_queries_not_using_indices.py
@@ -12,9 +12,8 @@ class TestQueriesNotUsingIndices(TestCase, DatabaseTestMixin):
         reports = list(check_queries_not_using_indices(
             database=self.connection, queries=read_queries_from_log('0019-queries-not-using-indices-log')))
 
-        print(list(map(str, reports)))
-
-        self.assertEqual(len(reports), 3)
+        print(*[f"{report.message} ({report.context['explain_extra']})" for report in reports], sep="\n")
+        assert len(reports) == 3
 
         self.assertEqual(str(reports[0]), '0019_queries_not_using_indices: "SELECT item_id FROM 0019_queries_not_using_indices..." query did not make use of any index')
         self.assertEqual(reports[0].table_name, '0019_queries_not_using_indices')

--- a/sql/0019-queries-not-using-indices-log
+++ b/sql/0019-queries-not-using-indices-log
@@ -13,3 +13,5 @@ SELECT 1 AS one FROM dual WHERE exists ( SELECT 1 FROM 0000_the_table WHERE item
 SELECT 1 AS one FROM dual WHERE exists ( SELECT item_id FROM 0019_queries_not_using_indices WHERE foo = "test" );
 -- #210: EXPLAINS' Extra says "Select tables optimized away"
 SELECT max(item_id) FROM 0019_queries_not_using_indices;
+-- #210: EXPLAINS' Extra says "No matching min/max row"
+SELECT max(item_id) FROM 0019_queries_not_using_indices_empty_table;

--- a/sql/0019-queries-not-using-indices-log
+++ b/sql/0019-queries-not-using-indices-log
@@ -11,3 +11,5 @@ SELECT foo FROM 0019_queries_not_using_indices WHERE item_id = 5;
 SELECT 1*1;
 SELECT 1 AS one FROM dual WHERE exists ( SELECT 1 FROM 0000_the_table WHERE item_id = 2 );
 SELECT 1 AS one FROM dual WHERE exists ( SELECT item_id FROM 0019_queries_not_using_indices WHERE foo = "test" );
+-- #210: EXPLAINS' Extra says "Select tables optimized away"
+SELECT max(item_id) FROM 0019_queries_not_using_indices;

--- a/sql/0019-queries-not-using-indices.sql
+++ b/sql/0019-queries-not-using-indices.sql
@@ -14,6 +14,7 @@ CREATE TABLE `0019_queries_not_using_indices` (
 DROP TABLE IF EXISTS `0019_queries_not_using_indices_empty_table`;
 CREATE TABLE `0019_queries_not_using_indices_empty_table` (
 	`item_id` int(9) NOT NULL AUTO_INCREMENT,
+	`foo` varchar(16) NOT NULL DEFAULT '',
 	PRIMARY KEY (`item_id`)
 );
 

--- a/sql/0019-queries-not-using-indices.sql
+++ b/sql/0019-queries-not-using-indices.sql
@@ -10,6 +10,13 @@ CREATE TABLE `0019_queries_not_using_indices` (
 	KEY `bar_idx` (`bar`)
 );
 
+-- https://github.com/macbre/index-digest/issues/210
+DROP TABLE IF EXISTS `0019_queries_not_using_indices_empty_table`;
+CREATE TABLE `0019_queries_not_using_indices_empty_table` (
+	`item_id` int(9) NOT NULL AUTO_INCREMENT,
+	PRIMARY KEY (`item_id`)
+);
+
 INSERT INTO 0019_queries_not_using_indices VALUES
     (1, 'test', ''),
     (2, 'foo', 'test'),


### PR DESCRIPTION
Fixes #210 

Ignore "Select tables optimized away":

> The query contained only aggregate functions (MIN(), MAX()) that were all resolved using an index, or COUNT(*) for MyISAM, and no GROUP BY clause. The optimizer determined that only one row should be returned.

And "No matching min/max row" - when the table is simply empty