### PR TITLE
Docker - use alpine as a base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,11 @@ sql/
 
 # READMEs
 *.md
+
+# other stuff
+*.log
+MANIFEST*
+Dockerfile
+
+**/__pycache__/**
+**/test/**

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,6 +10,18 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0.22
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: index_digest
+          MYSQL_USER: test
+          MYSQL_PASSWORD: p4ss
+        ports:
+        - "3306:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
     - uses: actions/checkout@v1
 
@@ -24,7 +36,10 @@ jobs:
           --tag ${{ github.repository }}
         docker images
 
-    - name: Run the container
+    - name: Check the version
       run: |
         docker run ${{ github.repository }} --version
   
+    - name: Run the container and connect to the test database
+      run: |
+        docker run ${{ github.repository }} mysql://test:p4ss@localhost/index_digest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -35,6 +35,7 @@ jobs:
           --cache-from macbre/index-digest:latest \
           --tag ${{ github.repository }}
         docker images
+        docker ps
 
     - name: Check the version
       run: |
@@ -42,4 +43,4 @@ jobs:
   
     - name: Run the container and connect to the test database
       run: |
-        docker run ${{ github.repository }} mysql://test:p4ss@localhost/index_digest
+        docker run ${{ github.repository }} mysql://test:p4ss@127.0.0.1/index_digest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,7 +19,7 @@ jobs:
           MYSQL_USER: test
           MYSQL_PASSWORD: p4ss
         ports:
-        - "3306:3306"
+        - "53306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
@@ -43,4 +43,4 @@ jobs:
   
     - name: Run the container and connect to the test database
       run: |
-        docker run ${{ github.repository }} mysql://test:p4ss@127.0.0.1/index_digest
+        docker run --network=host ${{ github.repository }} mysql://test:p4ss@0.0.0.0:53306/index_digest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -43,4 +43,5 @@ jobs:
   
     - name: Run the container and connect to the test database
       run: |
-        docker run --network=host ${{ github.repository }} mysql://test:p4ss@0.0.0.0:53306/index_digest
+        docker run --network=host ${{ github.repository }} mysql://test:p4ss@0.0.0.0:53306/index_digest | tee /tmp/results
+        grep "Jolly, good! No issues to report" /tmp/results

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -23,3 +23,8 @@ jobs:
           --cache-from macbre/index-digest:latest \
           --tag ${{ github.repository }}
         docker images
+
+    - name: Run the container
+      run: |
+        docker run ${{ github.repository }} --version
+  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/python/
-FROM python:3.9-slim-buster
+FROM python:3.9-alpine
 
 WORKDIR /opt/macbre/index-digest
 
@@ -9,10 +9,12 @@ ADD indexdigest/__init__.py ./indexdigest/__init__.py
 
 # installs mysql_config and pip dependencies
 # https://github.com/gliderlabs/docker-alpine/issues/181
-RUN apt-get update && apt-get install -y libmariadb-dev-compat gcc \
+RUN apk upgrade \
+    && apk add --virtual build-deps gcc musl-dev \
+    && apk add mariadb-dev \
     && pip install indexdigest \
     && rm -rf ~/.cache/pip \
-    && apt-get remove -y gcc && apt-get autoremove -y
+    && apk del build-deps
 
 # install the remaining files
 ADD . .


### PR DESCRIPTION
Despite https://pythonspeed.com/articles/alpine-docker-python/ wheels build takes around 4 seconds.

```
REPOSITORY                                          TAG                       IMAGE ID            CREATED              SIZE
macbre/index-digest                                 latest                    6d8642f9cb92        32 seconds ago       86.8MB
```

vs

```
REPOSITORY                                           TAG         IMAGE ID       CREATED         SIZE
macbre/index-digest                                  latest      27413be31ce3   2 seconds ago   186MB
```